### PR TITLE
Update demo.cpp

### DIFF
--- a/example/iris_mesh_demo/demo.cpp
+++ b/example/iris_mesh_demo/demo.cpp
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
     CLFML::FaceDetection::FaceDetector face_det;
     CLFML::IrisMesh::IrisMesh iris_det;
 
-    face_det.load_model(CFML_FACE_DETECTOR_CPU_MODEL_PATH);
+    face_det.load_model(CLFML_FACE_DETECTOR_CPU_MODEL_PATH);
     iris_det.load_model(CLFML_IRIS_MESH_CPU_MODEL_PATH);
 
     /* Create window to show the face roi */


### PR DESCRIPTION
Face detector model path typo fix. 

Currently the demo won't build :
![image](https://github.com/user-attachments/assets/af663cb4-951a-458c-80c0-4dc3bf3350fa)

With this fix it will.