### PR TITLE
Bugfix/roi out of plane crash

### DIFF
--- a/example/iris_mesh_demo/demo.cpp
+++ b/example/iris_mesh_demo/demo.cpp
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
     CLFML::FaceDetection::FaceDetector face_det;
     CLFML::IrisMesh::IrisMesh iris_det;
 
-    face_det.load_model(CFML_FACE_DETECTOR_CPU_MODEL_PATH);
+    face_det.load_model(CLFML_FACE_DETECTOR_CPU_MODEL_PATH);
     iris_det.load_model(CLFML_IRIS_MESH_CPU_MODEL_PATH);
 
     /* Create window to show the face roi */


### PR DESCRIPTION
(quick) Fixed issue : https://github.com/CLFML/Iris_Mesh.Cpp/issues/4

Now the demo won't crash when eye goes out image plane.

(Also typo fix for iris model path can be found in this branch)